### PR TITLE
Add start script to fix deployment error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview --host 0.0.0.0 --port ${PORT:-4173}"
+    "preview": "vite preview --host 0.0.0.0 --port ${PORT:-4173}",
+    "start": "vite preview --host 0.0.0.0 --port ${PORT:-4173}"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Purpose
The deployment was failing on Render with the error "Missing script start or file server.js". The user needed to add a start script to the package.json to resolve the deployment issue and get the application running successfully.

## Code changes
- Added a new `start` script to package.json that runs `vite preview --host 0.0.0.0 --port ${PORT:-4173}`
- The start script mirrors the existing preview script configuration to ensure consistent behavior
- This resolves the deployment error by providing the required start command that Render expects

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8d3c18bace6948da818d55c26020d064/aura-verse)

👀 [Preview Link](https://8d3c18bace6948da818d55c26020d064-aura-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8d3c18bace6948da818d55c26020d064</projectId>-->
<!--<branchName>aura-verse</branchName>-->